### PR TITLE
Proposal for media content such as images and files.

### DIFF
--- a/api.js
+++ b/api.js
@@ -67,8 +67,12 @@ client.on('ready', () => {
     console.log('Client is ready!');
 });
 
-client.on('message', msg => {
+client.on('message', async msg => {
     if (config.webhook.enabled) {
+        if (msg.hasMedia) {
+            const attachmentData = await msg.downloadMedia()
+            msg.attachmentData = attachmentData
+        }
         axios.post(config.webhook.path, { msg })
     }
 })


### PR DESCRIPTION
This option creates an attachmentData property in the message with the content of the media download, allowing the content to be received and processed at the endpoint configured as webhook.

The property looks like this.

```
"attachmentData": {
    "mimetype": ...,
    "data": base64 content,
    "filename": optional filename
}
```